### PR TITLE
fix: correctly render wrapped components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,4 +43,4 @@ Please checkout the [the open issues][issues]
 Also, please watch the repo and respond to questions/bug reports/feature requests! Thanks!
 
 [egghead]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
-[issues]: https://github.com/mihar-22/preact-testing-library/issues
+[issues]: https://github.com/testing-library/preact-testing-library/issues

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -89,7 +89,9 @@ test('renders options.wrapper around node', () => {
     <div
       data-testid="wrapper"
     >
-      <innerelement />
+      <div
+        data-testid="inner"
+      />
     </div>
   `);
 });

--- a/src/pure.js
+++ b/src/pure.js
@@ -29,11 +29,9 @@ function render(
   // they're passing us a custom container or not.
   mountedContainers.add(container);
 
-  const wrapUiIfNeeded = (innerElement) => (WrapperComponent ? (
-      <WrapperComponent>
-        <innerElement/>
-      </WrapperComponent>
-  ) : innerElement);
+  const wrapUiIfNeeded = (innerElement) => (WrapperComponent
+    ? h(WrapperComponent, null, innerElement)
+    : innerElement);
 
   preactAct(() => {
     if (hydrate) {


### PR DESCRIPTION
The render function now correctly renders the component if the wrapper option is set. Before
this it was rendering `<innerElement />` to the DOM.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Render the `WrapperComponent` directly using the `h` function and pass the `innerElement` as a child component rather than using JSX syntax in the function. This is how it is done in the react testing library as well.

Also updated the contributing link in the `CONTRIBUTING.md` file since the link pointed to a different project.

<!-- Why are these changes necessary? -->

**Why**:

Calling `render` with the wrapper option wasn't rendering the actual component, but `<innerElement />` so tests would fail due to the component being tested not existing.

<!-- How were these changes implemented? -->

**How**:

The `wrapUiIfNeeded`function was updated to directly create components using the `h` function.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added
- [x] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
