### PR TITLE
fix: flush pending hooks effects in rerender

### DIFF
--- a/src/__tests__/rerender.js
+++ b/src/__tests__/rerender.js
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/extend-expect'
 import { h } from 'preact'
+import { useState, useEffect } from 'preact/hooks'
 import { render } from '..'
 
 test('rerender will re-render the element', () => {
@@ -10,6 +11,23 @@ test('rerender will re-render the element', () => {
   expect(container.firstChild).toHaveTextContent('hi')
   rerender(<Greeting message="hey" />)
   expect(container.firstChild).toHaveTextContent('hey')
+})
+
+test('rerender will flush pending hooks effects', async () => {
+  const Component = () => {
+    const [value, setValue] = useState(0)
+    useEffect(() => {
+      const timeoutId = setTimeout(() => setValue(1), 0)
+      return () => clearTimeout(timeoutId)
+    })
+
+    return value
+  }
+
+  const { rerender, findByText } = render(<Component />)
+  rerender(<Component />)
+
+  await findByText('1')
 })
 
 test('hydrate will not update props until next render', () => {

--- a/src/pure.js
+++ b/src/pure.js
@@ -69,7 +69,7 @@ function render (
         : console.log(prettyDOM(el, maxLength, options)),
     unmount: () => preactRender(null, container),
     rerender: (rerenderUi) => {
-      setupRerender()()
+      act(() => {})
       render(wrapUiIfNeeded(rerenderUi), { container, baseElement })
       // Intentionally do not return anything to avoid unnecessarily complicating the API.
       // folks can use all the same utilities we return in the first place that are bound to


### PR DESCRIPTION
**What**:

Call preact/test-utils act which manages the same setupRerender behavior implemented previously in preact-testing-library, but also flushes any pending hook effects.

**Why**:

I had encountered an issue in one of my own projects using `@testing-library/preact-hooks` where calling hook's `setState` would not trigger a render, in a case where the state setter may be called asynchronously.

**How**:

This follows and defers to the internal [implementation of `preact/test-utils`'s `act` function](https://github.com/preactjs/preact/blob/134f65c6c8ec4107da30a82b348ce3c596da0c0e/test-utils/src/index.js#L18-L99), which also calls `setupRerender`'s resulting rerender function, but only after handling flushing behavior. The changes here effectively incorporate that behavior.

See also: https://github.com/preactjs/preact/pull/1437

**Checklist**:

- [ ] Documentation added (N/A)
- [x] Tests
- [ ] Typescript definitions updated (N/A)
- [x] Ready to be merged