### PR TITLE
feat: drop support for node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - '10'
   - '12'
   - '14'
+  - '16'
 script: npm run validate
 jobs:
   include:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/testing-library/preact-testing-library/issues"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12"
   },
   "keywords": [
     "testing",


### PR DESCRIPTION
BREAKING CHANGE: node 10 is no longer supported. It reached its end-of-life on 30.04.2021.

**What**:

Drop support for node 10

**Why**:

Reduces maintenance burden

**How**:

Change `engines` field to require `node>=12`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
