### PR TITLE
chore: update @testing-library dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/testing-library/preact-testing-library/issues"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12"
   },
   "keywords": [
     "testing",
@@ -49,7 +49,7 @@
     "contributors:generate": "all-contributors generate"
   },
   "dependencies": {
-    "@testing-library/dom": "^7.16.2"
+    "@testing-library/dom": "^8.11.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",
@@ -60,7 +60,7 @@
     "@babel/preset-env": "^7.5.5",
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
-    "@testing-library/jest-dom": "^5.10.1",
+    "@testing-library/jest-dom": "^5.16.1",
     "@types/jest": "^26.0.0",
     "all-contributors-cli": "^6.9.0",
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
BREAKING CHANGE: drops node 10 support

**What**:
Updated `@testing-library/dom` dependency and `@testing-library/jest-dom` dev dependency

**Why**:
Dependency requires some projects to have duplicate version of `@testing-library/dom`

**How**:
By updating package.json and updating engines entry

**Checklist**:

- [ ] Documentation added N/A
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
