### PR TITLE
feat: add esm support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/preset-env", { "targets": { "node": "8" } }]],
+    ["@babel/preset-env", { "targets": { "node": "12" } }]],
   "plugins": [
     ["@babel/plugin-proposal-class-properties"],
     ["@babel/plugin-transform-react-jsx", { "pragma": "h" }],

--- a/.babelrc.esm.json
+++ b/.babelrc.esm.json
@@ -1,0 +1,15 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "modules": false,
+        "targets": { "node": "12" }
+      }
+    ]
+  ],
+  "plugins": [
+    ["@babel/plugin-proposal-class-properties"],
+    ["@babel/plugin-transform-react-jsx", { "pragma": "h" }]
+  ]
+}

--- a/dont-clean-up-after-each.js
+++ b/dont-clean-up-after-each.js
@@ -1,1 +1,1 @@
-process.env.PTL_SKIP_AUTO_CLEANUP = true;
+process.env.PTL_SKIP_AUTO_CLEANUP = true

--- a/package.json
+++ b/package.json
@@ -2,8 +2,21 @@
   "name": "@testing-library/preact",
   "version": "0.0.0-semantically-released",
   "description": "Simple and complete Preact DOM testing utilities that encourage good testing practices.",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+			"types": "./types/index.d.ts",
+			"import": "./dist/esm/index.js",
+			"browser": "./dist/cjs/index.js"
+		},
+		"./pure": {
+			"types": "./pure.d.ts",
+			"import": "./dist/esm/pure.js",
+			"browser": "./dist/cjs/pure.js"
+		}
+  },
   "license": "MIT",
   "author": "Rahim Alwer <rahim_alwer@hotmail.com>",
   "homepage": "https://github.com/testing-library/preact-testing-library#readme",
@@ -33,13 +46,16 @@
     "dist",
     "dont-cleanup-after-each.js",
     "pure.js",
-    "types/index.d.ts"
+    "types/index.d.ts",
+    "pure.d.ts"
   ],
   "scripts": {
     "toc": "doctoc README.md",
     "lint": "eslint src/**/*.js --fix",
     "clean": "rimraf dist",
-    "build": " babel src --out-dir dist --ignore '**/__tests__/**,**/__mocks__/**'",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "babel src --out-dir dist/cjs --config-file ./.babelrc --ignore '**/__tests__/**,**/__mocks__/**'",
+    "build:esm": "babel src --no-babelrc --out-dir dist/esm --config-file ./.babelrc.esm.json --ignore '**/__tests__/**,**/__mocks__/**'",
     "test": "jest src/__tests__ ",
     "test:watch": "npm test --watch",
     "test:update": "npm test --updateSnapshot --coverage",

--- a/pure.js
+++ b/pure.js
@@ -1,2 +1,2 @@
 // Makes it so people can import from '@testing-library/preact/pure'
-module.exports = require('./dist/pure');
+module.exports = require('./dist/pure')


### PR DESCRIPTION
Resolves #50 
Resolves #36 

**What**:

This adds support for importing this library as ESM. Therefore we are also introducing the concept of export maps as this will allow people to use esm for all things testing library.

**Why**:

We are increasingly growing towards ESM as a baseline so we should support both modes.

**How**:

We initiate two Babel runs, one resulting in ESM and one resulting in CJS.

**Checklist**:

- [ ] Documentation added
- [ ] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
