### PR TITLE
fix(tests and events): resolves unsupported events and passing tests

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -125,15 +125,18 @@ const eventTypes = [
     type: 'Transition',
     events: ['transitionEnd'],
     elementType: 'div'
+  },
+  {
+    type: 'Pointer',
+    events: ['pointerEnter', 'pointerLeave'],
+    elementType: 'div'
   }
 ]
 
-eventTypes.forEach(({
-  type, events, elementType, init
-}) => {
+eventTypes.forEach(({ type, events, elementType, init }) => {
   describe(`${type} Events`, () => {
     events.forEach((eventName) => {
-      const eventProp = `on${eventName.toLowerCase()}`
+      const eventProp = `on${eventName[0].toUpperCase() + eventName.slice(1)}`
 
       it(`triggers ${eventProp}`, () => {
         const ref = createRef()
@@ -157,9 +160,9 @@ eventTypes.forEach(({
 test('onInput works', () => {
   const handler = jest.fn()
 
-  const { container: { firstChild: input } } = render(
-    (<input type="text" onInput={handler} />)
-  )
+  const {
+    container: { firstChild: input }
+  } = render(<input type="text" onInput={handler} />)
 
   expect(fireEvent.input(input, { target: { value: 'a' } })).toBe(true)
 
@@ -169,9 +172,9 @@ test('onInput works', () => {
 test('calling `fireEvent` directly works too', () => {
   const handler = jest.fn()
 
-  const { container: { firstChild: button } } = render(
-    (<button onClick={handler} />)
-  )
+  const {
+    container: { firstChild: button }
+  } = render(<button onClick={handler} />)
 
   expect(fireEvent(
     button,

--- a/src/file-event.js
+++ b/src/file-event.js
@@ -6,13 +6,9 @@ export const fireEvent = (...args) => domFireEvent(...args)
 
 Object.keys(domFireEvent).forEach((key) => {
   fireEvent[key] = (elem) => {
-    // when preact sets up an event listener it uses this check
-    // `'on' + eventName.toLowerCase() in dom`,
-    // to determine eventName from prop and this works in browser, but in jsdom if an event
-    // isn't supported, preact's check will
-    // fail and lead it to dispatch an event like `PointerStart` instead of `pointerStart`
-
-    // Here we can duplicate the check in preact and case the way preact will
+    // Preact registers event-listeners in lower-case, so onPointerStart becomes pointerStart
+    // here we will copy this behavior, when we fire an element we will fire it in lowercase so we hit
+    // the Preact listeners.
     const eventName = `on${key.toLowerCase()}`
     const isInElem = eventName in elem
     return isInElem

--- a/src/file-event.js
+++ b/src/file-event.js
@@ -1,0 +1,22 @@
+import { fireEvent as domFireEvent, createEvent } from '@testing-library/dom'
+
+// Similar to RTL we make are own fireEvent helper that just calls DTL's fireEvent with that
+// we can that any specific behaviors to the helpers we need
+export const fireEvent = (...args) => domFireEvent(...args)
+
+Object.keys(domFireEvent).forEach((key) => {
+  fireEvent[key] = (elem) => {
+    // when preact sets up an event listener it uses this check
+    // `'on' + eventName.toLowerCase() in dom`,
+    // to determine eventName from prop and this works in browser, but in jsdom if an event
+    // isn't supported, preact's check will
+    // fail and lead it to dispatch an event like `PointerStart` instead of `pointerStart`
+
+    // Here we can duplicate the check in preact and case the way preact will
+    const eventName = `on${key.toLowerCase()}`
+    const isInElem = eventName in elem
+    return isInElem
+      ? domFireEvent[key](elem)
+      : domFireEvent(elem, createEvent(key[0].toUpperCase() + key.slice(1), elem))
+  }
+})

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -7,8 +7,8 @@ export const fireEvent = (...args) => domFireEvent(...args)
 Object.keys(domFireEvent).forEach((key) => {
   fireEvent[key] = (elem) => {
     // Preact registers event-listeners in lower-case, so onPointerStart becomes pointerStart
-    // here we will copy this behavior, when we fire an element we will fire it in lowercase so we hit
-    // the Preact listeners.
+    // here we will copy this behavior, when we fire an element we will fire it in lowercase so
+    // wae hit the Preact listeners.
     const eventName = `on${key.toLowerCase()}`
     const isInElem = eventName in elem
     return isInElem

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -8,7 +8,7 @@ Object.keys(domFireEvent).forEach((key) => {
   fireEvent[key] = (elem) => {
     // Preact registers event-listeners in lower-case, so onPointerStart becomes pointerStart
     // here we will copy this behavior, when we fire an element we will fire it in lowercase so
-    // wae hit the Preact listeners.
+    // we hit the Preact listeners.
     const eventName = `on${key.toLowerCase()}`
     const isInElem = eventName in elem
     return isInElem

--- a/src/pure.js
+++ b/src/pure.js
@@ -1,7 +1,7 @@
 import { getQueriesForElement, prettyDOM, configure as configureDTL } from '@testing-library/dom'
 import { h, hydrate as preactHydrate, render as preactRender } from 'preact'
 import { act } from 'preact/test-utils'
-import { fireEvent } from './file-event'
+import { fireEvent } from './fire-event'
 
 configureDTL({
   asyncWrapper: async cb => {

--- a/src/pure.js
+++ b/src/pure.js
@@ -1,6 +1,7 @@
 import { getQueriesForElement, prettyDOM, configure as configureDTL } from '@testing-library/dom'
 import { h, hydrate as preactHydrate, render as preactRender } from 'preact'
-import { act, setupRerender } from 'preact/test-utils'
+import { act } from 'preact/test-utils'
+import { fireEvent } from './file-event'
 
 configureDTL({
   asyncWrapper: async cb => {
@@ -106,5 +107,7 @@ function cleanup () {
   mountedContainers.forEach(cleanupAtContainer)
 }
 
+// eslint-disable-next-line import/export
 export * from '@testing-library/dom'
-export { render, cleanup, act }
+// eslint-disable-next-line import/export
+export { render, cleanup, act, fireEvent }


### PR DESCRIPTION
fixes #51
fixes #23

I updated the test suite to use names for event handlers in camel case like users do( ie: `onClick` was being tested as `onclick`). Once this is corrected,
a number of tests will fail as JSDOM doesnt have support for them. When a user writea a component with a prop like `onPointerEnter`, preact will do something like `'on' + eventName.toLowerCase() in elem` and in jsdom that wont work. It leads to preact creating an event handler called `PointerEnter` rather than `pointerEnter`.

To solve I've overridden `fireEvent` similar to how its done in RTL, the difference is that we make the same check as preact, `eventName.toLowerCase() in dom`,  to determine what the dispatch event's name should be.

<!-- Why are these changes necessary? -->

Currently the PTL library typings indicate that this is supported and it also works fine in RTL.

<!-- How were these changes implemented? -->

First I fixed a test case then spent some time in a bugger to figure who was renaming the event names

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A ] Documentation added
- [ X] Tests
- [ N/A] Typescript definitions updated
- [X ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
