### PR TITLE
Include file extension in generated import specifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "clean": "rimraf dist",
     "build": "npm run build:cjs && npm run build:esm && npm run copy:mjs",
     "build:cjs": "babel src --out-dir dist/cjs --config-file ./.babelrc --ignore '**/__tests__/**,**/__mocks__/**'",
-    "build:esm": "babel src --no-babelrc --out-dir dist/esm --config-file ./.babelrc.esm.json --ignore '**/__tests__/**,**/__mocks__/**'",
+    "build:esm": "babel src --no-babelrc --out-file-extension .mjs --out-dir dist/esm --config-file ./.babelrc.esm.json --ignore '**/__tests__/**,**/__mocks__/**'",
     "copy:mjs": "cp ./dist/esm/fire-event.js ./dist/esm/fire-event.mjs && cp ./dist/esm/pure.js ./dist/esm/pure.mjs && cp ./dist/esm/index.js ./dist/esm/index.mjs",
     "test": "jest src/__tests__ ",
     "test:watch": "npm test --watch",


### PR DESCRIPTION
**What**:

This outputs imports like `import { pure } from "./pure.mjs"`

**Why**:

This change should fix vitest-dev/vitest#1375.

ES Module specifiers are URLs with no implied extension or index file resolution. Tools like Vite relax this to allow CommonJS-style `./index.js` resolution, but it's better to avoid relying on this since it's unspecified behavior.

**How**:

This uses the [`--out-file-extension` option](https://babeljs.io/docs/en/babel-cli#set-file-extensions) that was added to `@babel/cli` in version 7.8.0. It allows specifying a filename extension to use for generated import specifiers.

**Checklist**:

- [x] N/A Documentation added
- [x] N/A Tests
- [x] N/A Typescript definitions updated
- [x] Ready to be merged
