### PR TITLE
fix: pass arguments correctly

### DIFF
--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -5,14 +5,14 @@ import { fireEvent as domFireEvent, createEvent } from '@testing-library/dom'
 export const fireEvent = (...args) => domFireEvent(...args)
 
 Object.keys(domFireEvent).forEach((key) => {
-  fireEvent[key] = (elem) => {
+  fireEvent[key] = (element, init) => {
     // Preact registers event-listeners in lower-case, so onPointerStart becomes pointerStart
     // here we will copy this behavior, when we fire an element we will fire it in lowercase so
     // we hit the Preact listeners.
     const eventName = `on${key.toLowerCase()}`
     const isInElem = eventName in elem
     return isInElem
-      ? domFireEvent[key](elem)
-      : domFireEvent(elem, createEvent(key[0].toUpperCase() + key.slice(1), elem))
+      ? domFireEvent[key](element, init)
+      : domFireEvent(elem, createEvent(key[0].toUpperCase() + key.slice(1), init))
   }
 })

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -5,16 +5,16 @@ import { fireEvent as domFireEvent, createEvent } from '@testing-library/dom'
 export const fireEvent = (...args) => domFireEvent(...args)
 
 Object.keys(domFireEvent).forEach((key) => {
-  fireEvent[key] = (element, init) => {
+  fireEvent[key] = (elem, init) => {
     // Preact registers event-listeners in lower-case, so onPointerStart becomes pointerStart
     // here we will copy this behavior, when we fire an element we will fire it in lowercase so
     // we hit the Preact listeners.
     const eventName = `on${key.toLowerCase()}`
     const isInElem = eventName in elem
     if (isInElem) {
-      return domFireEvent[key](element, init)
+      return domFireEvent[key](elem, init)
     } else {
-      return domFireEvent(elem, createEvent(key[0].toUpperCase() + key.slice(1), element, init))
+      return domFireEvent(elem, createEvent(key[0].toUpperCase() + key.slice(1), elem, init))
     }
   }
 })

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -11,8 +11,10 @@ Object.keys(domFireEvent).forEach((key) => {
     // we hit the Preact listeners.
     const eventName = `on${key.toLowerCase()}`
     const isInElem = eventName in elem
-    return isInElem
-      ? domFireEvent[key](element, init)
-      : domFireEvent(elem, createEvent(key[0].toUpperCase() + key.slice(1), init))
+    if (isInElem) {
+      return domFireEvent[key](element, init)
+    } else {
+      return domFireEvent(elem, createEvent(key[0].toUpperCase() + key.slice(1), element, init))
+    }
   }
 })


### PR DESCRIPTION
Fixes #61 

**What**:

We did not pass `init` correctly to `domFireEvent`, this looks at the [signature of DomFireEvent](https://github.com/testing-library/dom-testing-library/blob/main/src/events.js) and passes init.

CC @mikerob215

**Checklist**:

- [ ] Documentation added
- [ ] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
