### PR TITLE
fix: fire event init

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -152,6 +152,9 @@ eventTypes.forEach(({ type, events, elementType, init }) => {
         expect(fireEvent[eventName](ref.current, init)).toBe(true)
 
         expect(spy).toHaveBeenCalledTimes(1)
+        if (init) {
+          expect(spy).toHaveBeenCalledWith(expect.objectContaining(init))
+        }
       })
     })
   })
@@ -164,9 +167,17 @@ test('onInput works', () => {
     container: { firstChild: input }
   } = render(<input type="text" onInput={handler} />)
 
-  expect(fireEvent.input(input, { target: { value: 'a' } })).toBe(true)
+  const targetProperties = { value: 'a' }
+  const otherProperties = { isComposing: true }
+  const init = {
+    target: targetProperties,
+    ...otherProperties
+  }
+
+  expect(fireEvent.input(input, init)).toBe(true)
 
   expect(handler).toHaveBeenCalledTimes(1)
+  expect(handler).toHaveBeenCalledWith(expect.objectContaining(otherProperties))
 })
 
 test('calling `fireEvent` directly works too', () => {
@@ -176,14 +187,16 @@ test('calling `fireEvent` directly works too', () => {
     container: { firstChild: button }
   } = render(<button onClick={handler} />)
 
-  expect(fireEvent(
-    button,
-    new Event('MouseEvent', {
-      bubbles: true,
-      cancelable: true,
-      button: 0
-    })
-  )).toBe(true)
+  const event = new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    button: 0
+  })
+
+  expect(fireEvent(button, event)).toBe(true)
+
+  expect(handler).toHaveBeenCalledTimes(1)
+  expect(handler).toHaveBeenCalledWith(event)
 })
 
 test('`fireEvent` returns false when prevented', () => {

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -5,14 +5,14 @@ import { fireEvent as domFireEvent, createEvent } from '@testing-library/dom'
 export const fireEvent = (...args) => domFireEvent(...args)
 
 Object.keys(domFireEvent).forEach((key) => {
-  fireEvent[key] = (elem) => {
+  fireEvent[key] = (elem, init) => {
     // Preact registers event-listeners in lower-case, so onPointerStart becomes pointerStart
     // here we will copy this behavior, when we fire an element we will fire it in lowercase so
     // we hit the Preact listeners.
     const eventName = `on${key.toLowerCase()}`
     const isInElem = eventName in elem
     return isInElem
-      ? domFireEvent[key](elem)
-      : domFireEvent(elem, createEvent(key[0].toUpperCase() + key.slice(1), elem))
+      ? domFireEvent[key](elem, init)
+      : domFireEvent(elem, createEvent(key[0].toUpperCase() + key.slice(1), elem, init))
   }
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Preact specific `fireEvent` is broken: https://github.com/testing-library/preact-testing-library/issues/61

<!-- Why are these changes necessary? -->

**Why**:

`fireEvent` API is broken after preact specific changes

<!-- How were these changes implemented? -->

**How**:

Updated existing event tests to demonstrate the regression, fixed the tests by adding init to the preact specific `fireEvent`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
- [X] Tests
- [ ] Typescript definitions updated N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I'm not entirely sure how the type definitions work for the methods that are inherited from other testing-library libraries, so not sure if anything needs to be done so I marked it as N/A. These changes _should_ bring the `fireEvent` in the preact library more in line with `fireEvent` from dom.
