### PR TITLE
fix: Guard against `process` not being defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { cleanup } from './pure'
 // this ensures that tests run in isolation from each other.
 // If you don't like this then either import the `pure` module
 // or set the PTL_SKIP_AUTO_CLEANUP env variable to 'true'.
-if (!process.env.PTL_SKIP_AUTO_CLEANUP) {
+if (typeof process === "undefined" || !process.env.PTL_SKIP_AUTO_CLEANUP) {
   if (typeof afterEach === 'function') {
     afterEach(async () => {
       await cleanup()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Check for `process` being defined.

<!-- Why are these changes necessary? -->

**Why**: Webpack 5 doesn't shim Node's `process` object by default anymore. Only instances of `process.env.NODE_ENV` are replaced statically. This means that unguarded checks of `process.env` will crash in browser environments (such as Karma).

<!-- How were these changes implemented? -->

**How**: Check for `process` being defined. This is a port of testing-library/react-testing-library#911

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
