### PR TITLE
fix: onchange event with preact/compat enabled

### DIFF
--- a/src/__tests__/events-compat.js
+++ b/src/__tests__/events-compat.js
@@ -1,14 +1,12 @@
 import { h } from 'preact' // required by render
 import { fireEvent, render } from '..'
-import { forwardRef } from 'preact/compat' // required for this test to make sense
+import from 'preact/compat'
 
 test('calling `fireEvent` with `preact/compat` and onChange works too', () => {
   const handler = jest.fn()
 
-  // forwardRef needs to be imported from preact/compat for this test to make sense.
-  // Preact behavior when using onChange is described here:
-  // https://preactjs.com/guide/v10/differences-to-react#use-oninput-instead-of-onchange
-  // We want to test if onChange event gets caught with fireEvent.change()
+  // Preact only matches React's aliasing of `onChange` when `preact/compat` is used
+  // This test ensures this is supported properly with `fireEvent.change()`
   const {
     container: { firstChild: input }
   } = render(<input type="text" onChange={handler} />)

--- a/src/__tests__/events-compat.js
+++ b/src/__tests__/events-compat.js
@@ -1,6 +1,6 @@
 import { h } from 'preact' // required by render
 import { fireEvent, render } from '..'
-import from 'preact/compat'
+import 'preact/compat'
 
 test('calling `fireEvent` with `preact/compat` and onChange works too', () => {
   const handler = jest.fn()

--- a/src/__tests__/events-compat.js
+++ b/src/__tests__/events-compat.js
@@ -1,0 +1,27 @@
+import { h } from 'preact' // required by render
+import { fireEvent, render } from '..'
+import { forwardRef } from 'preact/compat' // required for this test to make sense
+
+test('calling `fireEvent` with `preact/compat` and onChange works too', () => {
+  const handler = jest.fn()
+
+  // forwardRef needs to be imported from preact/compat for this test to make sense.
+  // Preact behavior when using onChange is described here:
+  // https://preactjs.com/guide/v10/differences-to-react#use-oninput-instead-of-onchange
+  // We want to test if onChange event gets caught with fireEvent.change()
+  const {
+    container: { firstChild: input }
+  } = render(<input type="text" onChange={handler} />)
+
+  const targetProperties = { value: 'a' }
+  const otherProperties = { isComposing: true }
+  const init = {
+    target: targetProperties,
+    ...otherProperties
+  }
+
+  expect(fireEvent.change(input, init)).toBe(true)
+
+  expect(handler).toHaveBeenCalledTimes(1)
+  expect(handler).toHaveBeenCalledWith(expect.objectContaining(otherProperties))
+})

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -1,6 +1,5 @@
 import { createRef, h } from 'preact'
 import { fireEvent, render } from '..'
-import { forwardRef } from 'preact/compat'
 
 const eventTypes = [
   {
@@ -176,30 +175,6 @@ test('onInput works', () => {
   }
 
   expect(fireEvent.input(input, init)).toBe(true)
-
-  expect(handler).toHaveBeenCalledTimes(1)
-  expect(handler).toHaveBeenCalledWith(expect.objectContaining(otherProperties))
-})
-
-test.only('calling `fireEvent` with `preact/compat` and onChange works too', () => {
-  const handler = jest.fn()
-
-  // forwardRef needs to be imported from preact/compat for this test to make sense.
-  // Preact behavior when using onChange is described here:
-  // https://preactjs.com/guide/v10/differences-to-react#use-oninput-instead-of-onchange
-  // We want to test if onChange event gets caught with fireEvent.change()
-  const {
-    container: { firstChild: input }
-  } = render(<input type="text" onChange={handler} />)
-
-  const targetProperties = { value: 'a' }
-  const otherProperties = { isComposing: true }
-  const init = {
-    target: targetProperties,
-    ...otherProperties
-  }
-
-  expect(fireEvent.change(input, init)).toBe(true)
 
   expect(handler).toHaveBeenCalledTimes(1)
   expect(handler).toHaveBeenCalledWith(expect.objectContaining(otherProperties))

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -30,7 +30,7 @@ const eventTypes = [
   },
   {
     type: 'Focus',
-    events: ['input', 'invalid'],
+    events: ['input', 'invalid', 'change'],
     elementType: 'input'
   },
   {

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -1,5 +1,6 @@
 import { createRef, h } from 'preact'
 import { fireEvent, render } from '..'
+import { forwardRef } from 'preact/compat'
 
 const eventTypes = [
   {
@@ -180,6 +181,30 @@ test('onInput works', () => {
   expect(handler).toHaveBeenCalledWith(expect.objectContaining(otherProperties))
 })
 
+test.only('calling `fireEvent` with `preact/compat` and onChange works too', () => {
+  const handler = jest.fn()
+
+  // forwardRef needs to be imported from preact/compat for this test to make sense.
+  // Preact behavior when using onChange is described here:
+  // https://preactjs.com/guide/v10/differences-to-react#use-oninput-instead-of-onchange
+  // We want to test if onChange event gets caught with fireEvent.change()
+  const {
+    container: { firstChild: input }
+  } = render(<input type="text" onChange={handler} />)
+
+  const targetProperties = { value: 'a' }
+  const otherProperties = { isComposing: true }
+  const init = {
+    target: targetProperties,
+    ...otherProperties
+  }
+
+  expect(fireEvent.change(input, init)).toBe(true)
+
+  expect(handler).toHaveBeenCalledTimes(1)
+  expect(handler).toHaveBeenCalledWith(expect.objectContaining(otherProperties))
+})
+
 test('calling `fireEvent` directly works too', () => {
   const handler = jest.fn()
 
@@ -200,8 +225,14 @@ test('calling `fireEvent` directly works too', () => {
 })
 
 test('`fireEvent` returns false when prevented', () => {
-  const { container: { firstChild: button } } = render(
-    (<button onClick={(e) => { e.preventDefault() }} />)
+  const {
+    container: { firstChild: button }
+  } = render(
+    <button
+      onClick={(e) => {
+        e.preventDefault()
+      }}
+    />
   )
 
   expect(fireEvent.click(button)).toBe(false)

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -16,6 +16,7 @@ Object.keys(domFireEvent).forEach((key) => {
     // making the event name out of sync.
     // The problematic code is in: preact/compat/src/render.js > handleDomVNode()
     const keyFiltered = key === 'change' ? 'input' : key
+
     return isInElem
       ? domFireEvent[keyFiltered](elem, init)
       : domFireEvent(

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -11,8 +11,16 @@ Object.keys(domFireEvent).forEach((key) => {
     // we hit the Preact listeners.
     const eventName = `on${key.toLowerCase()}`
     const isInElem = eventName in elem
+    // Preact changes all change events to input events. This is normally handled directly
+    // but when running 'preact/compat' this is done via custom JS which renames the event prop,
+    // making the event name out of sync.
+    // The problematic code is in: preact/compat/src/render.js > handleDomVNode()
+    const keyFiltered = key === 'change' ? 'input' : key
     return isInElem
-      ? domFireEvent[key](elem, init)
-      : domFireEvent(elem, createEvent(key[0].toUpperCase() + key.slice(1), elem, init))
+      ? domFireEvent[keyFiltered](elem, init)
+      : domFireEvent(
+        elem,
+        createEvent(keyFiltered[0].toUpperCase() + keyFiltered.slice(1), elem, init)
+      )
   }
 })


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: 
This is a fix to a bug that I found: https://github.com/vitest-dev/vitest/discussions/5456
It took me a while to figure out where exactly is the issue so the communication spans vitest and preact forums as well.

<!-- Why are these changes necessary? -->

**Why**:
Because `preact/compat` library renames props before establishing events, the events are listening under different name (specifically, `onChange` listens to `input` event). So, when firing event via `fireEvent.change()` the event also needs to be translated so that it gets triggered.
This can be avoided in code by using `fireEvent.input()` in tests, but since Preact documentation does not imperatively rule out using `onChange` I think the testing library should support it also. Furthermore, `onChange` is available because of compatibility with React where `fireEvent.change()` also works.

<!-- How were these changes implemented? -->

**How**:
Added condition into fire-event.js.
Added dedicated test for this condition.
Both are properly commented to explain the logic and reasoning.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

**Comments**:
During testing I also found out there are 15 other events which have issues because of this (mostly animation, touch and composition events, and also focus and blur). If you agree with my approach, I could also try to fix the rest in a separate branch.