### PR TITLE
fix: correct type of `wrapper` property in `RenderOptions`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,7 @@ export interface RenderOptions<Q extends Queries = typeof queries> {
   container?: Element
   baseElement?: Element
   queries?: Q
-  wrapper?: ComponentChild
+  wrapper?: ComponentType<{ children: Element }>
 }
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

The type of `wrapper` property in `RenderOptions` is mistyped, causing the `children` prop to be inferred as `any`.

![Screenshot](https://github.com/testing-library/preact-testing-library/assets/9212875/682bab46-562d-4537-8dd3-309d189b57b3)

<!-- Why are these changes necessary? -->

**Why**:

The `wrapper` property should be a **component** instead of an **element**, just like that in `RenderHookOptions`.

<!-- How were these changes implemented? -->

**How**:

The type of `wrapper` property in `RenderOptions` is changed from `ComponentChild` to `ComponentType<{ children: Element }>`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added `N/A`
- [ ] Tests `N/A`
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
