### PR TITLE
fix: type RenderHookOptions.wrapper with preact ComponentChildren

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import { queries, Queries, BoundFunction } from '@testing-library/dom'
 import { act as preactAct } from 'preact/test-utils'
-import { ComponentChild, ComponentType } from 'preact'
+import { ComponentChild, ComponentChildren, ComponentType } from 'preact'
 
 export * from '@testing-library/dom'
 
@@ -81,7 +81,7 @@ export interface RenderHookOptions<Props> {
    *
    *  @see https://testing-library.com/docs/react-testing-library/api/#wrapper
    */
-  wrapper?: ComponentType<{ children: Element }>
+  wrapper?: ComponentType<{ children?: ComponentChildren }>
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #81.

`RenderHookOptions.wrapper` was typed as `ComponentType<{ children: Element }>`. Here `Element` resolves to the DOM `Element` global rather than a preact/JSX type, so a normal wrapper component (context providers, etc.) typed with `ComponentChildren` / `PropsWithChildren` is not assignable, producing a TS2322 error at every `renderHook` call that passes a `wrapper`.

This changes the type to `ComponentType<{ children?: ComponentChildren }>`, using preact's `ComponentChildren` and making `children` optional, matching how wrapper components are actually typed.

## Changes

- Import `ComponentChildren` from `preact`.
- `wrapper?: ComponentType<{ children: Element }>` → `wrapper?: ComponentType<{ children?: ComponentChildren }>`.

## Testing

- `npm test` — 13 suites / 104 tests pass.
- `npm run build` — CJS + ESM compile successfully.

The change is type-only; no runtime code changed.